### PR TITLE
Optional contentSetting and metadata objects

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -14,6 +14,8 @@ module.exports = function (opts) {
 	if (!opts.container) {
 		throw new Error('Missing container option.');
 	}
+	var metadata = opts.metadata || {}
+	var contentSettings = opts.contentSettings || {}
 	var prefix = opts.prefix || '';
 	var service = azure.createBlobService(opts.account, opts.key).withFilter(new azure.LinearRetryPolicyFilter());
 	var q = queue({ concurrency: 4, timeout: 1000 * 60 * 2 });
@@ -30,7 +32,7 @@ module.exports = function (opts) {
 			var ostream = service.createWriteStreamToBlockBlob(
 				opts.container,
 				prefix + file.relative,
-				{ metadata: { fsmode: file.stat.mode }, contentSettings: {contentType: mime.lookup(file.relative)}},
+				{ metadata: Object.assign({ fsmode: file.stat.mode }, metadata), contentSettings: Object.assign({contentType: mime.lookup(file.relative)}, contentSettings)},
 				function(err) {
 					if (err) { return cb(err); }
 


### PR DESCRIPTION
With this simple modification, it is possible to pass to the gulp task also a metadata object and a contentSettings object in order to configure the blob properties. Example code for the gulpfile.js:

```javascript
...
gulp.task('azure-upload', function(cb) {
    return gulp
        .src('dist/**')
        .pipe(azure.upload({
            account: 'ACCOUNT',
            key: 'KEY',
            container: 'CONTAINER',
            contentSettings: { cacheControl: 'public, no-cache' },
            metadata: { docType: 'textDocuments'}
        }))
})
...
```